### PR TITLE
Refactor namespaces and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 .idea/
+/.vs/Friday

--- a/Friday/Abstractions/INotification.cs
+++ b/Friday/Abstractions/INotification.cs
@@ -1,3 +1,3 @@
-namespace Infrastructure.FridayMediator.Abstractions;
+namespace Friday.Abstractions;
 
 public interface INotification { }

--- a/Friday/Abstractions/INotificationHandler.cs
+++ b/Friday/Abstractions/INotificationHandler.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Infrastructure.FridayMediator.Abstractions;
+namespace Friday.Abstractions;
 
 public interface INotificationHandler<in TNotification>
     where TNotification : INotification

--- a/Friday/Abstractions/IRequest.cs
+++ b/Friday/Abstractions/IRequest.cs
@@ -1,3 +1,3 @@
-namespace Infrastructure.FridayMediator.Abstractions;
+namespace Friday.Abstractions;
 
 public interface IRequest<out TResponse>;

--- a/Friday/Abstractions/IRequestHandler.cs
+++ b/Friday/Abstractions/IRequestHandler.cs
@@ -1,8 +1,7 @@
-
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Infrastructure.FridayMediator.Abstractions;
+namespace Friday.Abstractions;
 
 public interface IRequestHandler<in TRequest, TResponse>
     where TRequest : IRequest<TResponse>

--- a/Friday/Behaviors/IPipelineBehavior.cs
+++ b/Friday/Behaviors/IPipelineBehavior.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Infrastructure.FridayMediator.Abstractions;
+using Friday.Abstractions;
 
-namespace Infrastructure.FridayMediator.Behaviors;
+namespace Friday.Behaviors;
 
 public interface IPipelineBehavior<in TRequest, TResponse>
     where TRequest : IRequest<TResponse>

--- a/Friday/Core/Friday.cs
+++ b/Friday/Core/Friday.cs
@@ -5,12 +5,12 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Infrastructure.FridayMediator.Abstractions;
-using Infrastructure.FridayMediator.Behaviors;
+using Friday.Abstractions;
+using Friday.Behaviors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Infrastructure.FridayMediator.Core;
+namespace Friday.Core;
 
 //Mediator is a design pattern that allows for decoupling of components in a system by using a central hub to manage communication between them. Mediator's name is derived from the Latin word "mediator," which means "one who mediates or intervenes." In software design, the Mediator pattern is used to reduce dependencies between components, making it easier to maintain and extend the system. The pattern promotes loose coupling by allowing components to communicate through a mediator object rather than directly with each other. This can lead to a more organized and manageable codebase, especially in complex systems with many interacting components. It is named after Friday inspired by Tony Stark's AI assistant after Jarvis.
 public interface IFriday

--- a/Friday/Core/ServiceCollectionExtensions.cs
+++ b/Friday/Core/ServiceCollectionExtensions.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Infrastructure.FridayMediator.Abstractions;
+using Friday.Abstractions;
 using Infrastructure.FridayMediator.Behaviors;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Infrastructure.FridayMediator.Core;
+namespace Friday.Core;
 
 public static class ServiceCollectionExtensions
 {

--- a/Friday/Samples/PingRequest.cs
+++ b/Friday/Samples/PingRequest.cs
@@ -1,8 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Infrastructure.FridayMediator.Abstractions;
+using Friday.Abstractions;
 
-namespace Infrastructure.FridayMediator.Samples;
+namespace Friday.Samples;
 
 public record PingRequest : IRequest<Result>
 {


### PR DESCRIPTION
Refactored namespaces from `Infrastructure.FridayMediator.*` to `Friday.*` across multiple files for consistency and conciseness. Updated `using` statements to reflect the new namespace structure.

Updated `.gitignore` to include `.vs/Friday` and `.idea/` directories, while removing outdated entries like
`-.idea/` and `/_ReSharper.Caches/`.